### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security_audit.yml
+++ b/.github/workflows/security_audit.yml
@@ -1,4 +1,6 @@
 name: Security audit
+permissions:
+  contents: read
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/kevintprivett/Ginzu-Valuation/security/code-scanning/1](https://github.com/kevintprivett/Ginzu-Valuation/security/code-scanning/1)

In general, to fix this issue you explicitly declare a `permissions:` block for the workflow or for individual jobs, restricting the GITHUB_TOKEN to the minimal scopes needed. For a read-only audit job like this, `contents: read` is typically sufficient; no write permissions are necessary.

The best minimal fix here is to add a workflow-level `permissions:` block right after the workflow `name:` (before `on:`). This will apply to all jobs in this workflow, including `security-audit`, and avoids repeating configuration per job. Given the current steps (checkout, setup-node, `npm ci`, `npm audit`), none require write access to repository contents or other resources, so setting `permissions: contents: read` will not break existing behavior. No imports or additional methods are involved, since this is purely YAML configuration. Concretely, in `.github/workflows/security_audit.yml`, between line 1 (`name: Security audit`) and line 3 (`on:`), insert:

```yaml
permissions:
  contents: read
```

This directly addresses the CodeQL warning and enforces least-privilege defaults for the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
