### PR TITLE
Monthly ERP Update - 2026-01-21

### DIFF
--- a/FrontEnd/src/utils/marketData.json
+++ b/FrontEnd/src/utils/marketData.json
@@ -1604,7 +1604,7 @@
       "ERP": 5.01
     },
     "United States": {
-      "ERP": 4.2
+      "ERP": 4.18
     },
     "Uruguay": {
       "ERP": 6.3


### PR DESCRIPTION
This PR updates the Equity Risk Premium (ERP) data used in the Ginzu application.
The ERP has been updated to reflect the latest market conditions as of 2026-01-21.