### PR TITLE
Monthly ERP Update - 2026-05-05

### DIFF
--- a/FrontEnd/src/utils/marketData.json
+++ b/FrontEnd/src/utils/marketData.json
@@ -1584,7 +1584,7 @@
       "ERP": 5.01
     },
     "United States": {
-      "ERP": 4.67
+      "ERP": 4.24
     },
     "Uruguay": {
       "ERP": 6.3


### PR DESCRIPTION
This PR updates the Equity Risk Premium (ERP) data used in the Ginzu application.
The ERP has been updated to reflect the latest market conditions as of 2026-05-05.