### PR TITLE
Monthly ERP Update - 2026-08-05

### DIFF
--- a/FrontEnd/src/utils/marketData.json
+++ b/FrontEnd/src/utils/marketData.json
@@ -1584,7 +1584,7 @@
       "ERP": 5.01
     },
     "United States": {
-      "ERP": 4.18
+      "ERP": 4.28
     },
     "Uruguay": {
       "ERP": 6.3


### PR DESCRIPTION
This PR updates the Equity Risk Premium (ERP) data used in the Ginzu application.
The ERP has been updated to reflect the latest market conditions as of 2026-08-05.